### PR TITLE
Rename search columns after merge

### DIFF
--- a/src/pipelines/finalize.py
+++ b/src/pipelines/finalize.py
@@ -110,30 +110,28 @@ if __name__ == "__main__":
          "potential_disposal_company": "potential_disposal_company",
      }
 
-     df_search = run_pipeline_sync(
-         df_results,
-         search_chain,
-         partial_dir=args.partial_dir,
-         final_path=str(Path(args.output_dir) / "search_results.csv"),
-         cols_mapping=search_cols_mapping,
-         max_retries=4,
-         initial_delay=3.0,
-         partial_every=2800,
-     )
-
-     df_search = df_search.rename(
-         columns={
-             "financial_group_hq": "group_hq",
-             "group_vertical": "vertical",
-             "potential_disposal_industry": "disposal_nc_sector",
-         }
-     )
-
-     df_results = df_results.drop(
-         columns=["source_name", "article_fragment", "potential_disposal_company"],
-         errors="ignore",
-     )
-     df_results = df_results.merge(df_search, on="index", how="left")
+    df_search = run_pipeline_sync(
+        df_results,
+        search_chain,
+        partial_dir=args.partial_dir,
+        final_path=str(Path(args.output_dir) / "search_results.csv"),
+        cols_mapping=search_cols_mapping,
+        max_retries=4,
+        initial_delay=3.0,
+        partial_every=2800,
+    )
+    df_results = df_results.drop(
+        columns=["source_name", "article_fragment", "potential_disposal_company"],
+        errors="ignore",
+    )
+    df_results = df_results.merge(df_search, on="index", how="left")
+    df_results = df_results.rename(
+        columns={
+            "financial_group_hq": "group_hq",
+            "group_vertical": "vertical",
+            "potential_disposal_industry": "disposal_nc_sector",
+        }
+    )
 
      logging.info(f"Extraction completed, merging full results with original data")
 


### PR DESCRIPTION
## Summary
- rename search result columns on `df_results` after merge
- ensure `grouped_summary` uses renamed column names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c99528d70833397dbf53530b35264