### PR TITLE
Handle pre-existing index column

### DIFF
--- a/src/df_llm_processor/processor.py
+++ b/src/df_llm_processor/processor.py
@@ -245,7 +245,10 @@ async def process_df_rows(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # dataframe → list[dict]
-    rows: List[Dict[str, Any]] = df.rename(columns=cols_mapping).reset_index().to_dict(orient="records") #type: ignore
+    df = df.rename(columns=cols_mapping)
+    if "index" in df.columns:
+        df = df.rename(columns={"index": "original_index"})
+    rows: List[Dict[str, Any]] = df.reset_index().to_dict(orient="records") #type: ignore
 
     # Inject current date in ISO format for prompt recency/completeness assessments
     today_iso = datetime.now().strftime("%Y-%m-%d")

--- a/src/pipelines/finalize.py
+++ b/src/pipelines/finalize.py
@@ -191,6 +191,11 @@ if __name__ == "__main__":
           partial_every=2800,
      )
 
+     if "original_index" in df_search.columns:
+          df_search = df_search.drop(columns=["index"], errors="ignore").rename(
+               columns={"original_index": "index"}
+          )
+
      df_results = df_results.drop(
           columns=["source_name", "article_fragment", "potential_disposal_company"],
           errors="ignore",


### PR DESCRIPTION
## Summary
- Preserve user-provided `index` column by renaming it to `original_index` before resetting index during LLM processing.
- Normalize search enrichment outputs by restoring `original_index` to `index` prior to merging.

## Testing
- `python -m py_compile src/df_llm_processor/processor.py src/pipelines/finalize.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2e7efb2048333800a6247cf4580fc